### PR TITLE
Add September to monthly demand plot x-axis labels

### DIFF
--- a/Mothercell/Hive.IO/Hive.IO/GHComponents/GHVisualizer.cs
+++ b/Mothercell/Hive.IO/Hive.IO/GHComponents/GHVisualizer.cs
@@ -361,6 +361,7 @@ namespace Hive.IO
                     "J",
                     "J",
                     "A",
+                    "S",
                     "O",
                     "N",
                     "D"


### PR DESCRIPTION
This PR fixes #251 - missing "S" in the x-axis labels for the monthly demand plot.