### PR TITLE
364 fixes to energy systems form

### DIFF
--- a/src/Hive.IO/Hive.IO/Forms/ConversionTechPropertiesViewModel.cs
+++ b/src/Hive.IO/Hive.IO/Forms/ConversionTechPropertiesViewModel.cs
@@ -30,9 +30,14 @@ namespace Hive.IO.Forms
 
         public static IEnumerable<string> AllNames => Defaults.Keys;
 
+        public ConversionTechPropertiesViewModel()
+        {
+            Name = "Photovoltaic (PV)";
+        }
+
         public string Name
         {
-            get => _name ?? "Photovoltaic (PV)";
+            get => _name;
             set
             {
                 if (AllNames.Contains(value))
@@ -199,6 +204,8 @@ namespace Hive.IO.Forms
             {
                 ModuleType = ModuleTypesCatalog.ContainsKey(Name) ? ModuleTypesCatalog[Name].First() : new ModuleTypeRecord { Name = "<custom>" };
             }
+
+            RaisePropertyChangedEvent(null);
         }
 
         private void SelectSurfaces(IEnumerable<SurfaceViewModel> surfaces)

--- a/src/Hive.IO/Hive.IO/GHComponents/GhEnergySystem.cs
+++ b/src/Hive.IO/Hive.IO/GHComponents/GhEnergySystem.cs
@@ -136,11 +136,7 @@ namespace Hive.IO.GHComponents
                             solarProperties.EmbodiedEmissions, solarProperties.MeshSurface,
                             solarProperties.Technology));
 
-            if (conversionTechProperties == null)
-            {
-                conversionTech.Add(new GasBoiler(100.0, 100.0, 10.0, 0.9));
-            }
-            else
+            if (conversionTechProperties != null)
             {
                 if (conversionTechProperties.ASHPCapacity > 0.0)
                     conversionTech.Add(new AirSourceHeatPump(conversionTechProperties.ASHPCost,
@@ -169,27 +165,21 @@ namespace Hive.IO.GHComponents
             }
 
             var emitters = new List<Emitter>();
-            if (emitterProperties.Count == 0)
+            foreach (var emProp in emitterProperties)
             {
-                emitters.Add(new Radiator(100.0, 100.0, true, false, 65.0, 55.0));
-                emitters[0].SetEmitterName("ConventionalRadiator");
-                emitters.Add(new AirDiffuser(100.0, 100.0, false, true, 20.0, 25.0));
-                emitters[1].SetEmitterName("AirDiffuser");
-            }
-            else
-            {
-                var counter = 0;
-                foreach (var emProp in emitterProperties)
+                Emitter emitter;
+                if (emProp.IsRadiation)
                 {
-                    if (emProp.IsRadiation)
-                        emitters.Add(new Radiator(emProp.InvestmentCost, emProp.EmbodiedEmissions, emProp.IsHeating,
-                            emProp.IsCooling, emProp.SupplyTemperature, emProp.ReturnTemperature));
-                    else
-                        emitters.Add(new AirDiffuser(emProp.InvestmentCost, emProp.EmbodiedEmissions, emProp.IsHeating,
-                            emProp.IsCooling, emProp.SupplyTemperature, emProp.ReturnTemperature));
-                    emitters[counter].SetEmitterName(emProp.Name);
-                    counter++;
+                    emitter = new Radiator(emProp.InvestmentCost, emProp.EmbodiedEmissions, emProp.IsHeating,
+                        emProp.IsCooling, emProp.SupplyTemperature, emProp.ReturnTemperature);
                 }
+                else
+                {
+                    emitter = new AirDiffuser(emProp.InvestmentCost, emProp.EmbodiedEmissions, emProp.IsHeating,
+                        emProp.IsCooling, emProp.SupplyTemperature, emProp.ReturnTemperature);
+                }
+                emitter.SetEmitterName(emProp.Name);
+                emitters.Add(emitter);
             }
 
             // create a viewmodel for the form (note, it get's set to null when the input values change...)

--- a/src/Hive.IO/Hive.IO/GHComponents/GhEnergySystem.cs
+++ b/src/Hive.IO/Hive.IO/GHComponents/GhEnergySystem.cs
@@ -216,7 +216,7 @@ namespace Hive.IO.GHComponents
             }
 
             // remove parametrically defined conversion technologies and emitters - they'll be added below anyway
-            var oldMeshes = _viewModel.Surfaces.Where(s => !s.Connection.IsParametricDefined).ToArray();
+            var oldMeshes = _viewModel.Surfaces.Where(s => s.Connection == null || !s.Connection.IsParametricDefined).ToArray();
             var formDefinedConversionTech = _viewModel.ConversionTechnologies.Where(ct => !ct.IsParametricDefined).ToArray();
             var formDefinedEmitters = _viewModel.Emitters.Where(e => !e.IsParametricDefined).ToArray();
             _viewModel.ConversionTechnologies.Clear();

--- a/src/Hive.IO/Hive.IO/GHComponents/GhEnergySystem.cs
+++ b/src/Hive.IO/Hive.IO/GHComponents/GhEnergySystem.cs
@@ -227,7 +227,7 @@ namespace Hive.IO.GHComponents
                 switch (ct)
                 {
                     case GasBoiler gasBoiler:
-                        ctvm.Name = "Boiler(Gas)";
+                        ctvm.Name = "Boiler (Gas)";
                         ctvm.SetProperties(gasBoiler);
                         break;
 


### PR DESCRIPTION
fixes issues that showed up regarding  PR #380:

> some problems I just found now, unfortunately:
>
>    adding a new EnergySystems Form onto the canvas results in an error (1. Solution exception:Invalid 
> ConversionTechPropertiesViewModel.Name: Boiler(Gas)). Also, opening the form with a double click does work, but no 
> conversion nor emitter technologies can be added via the form.
    something is wrong with persistent variables in this component. the order of how you connect parametric-inputs to it and WHEN you open the form with a double click determines whether it works or not. Also, disconnecting a parametric-input from the component doesn't purge the entries in the form
    if the form works, 2 emitters are created automatically (Radiator and AirDiffuser), which should not happen. They need to be added first by the user

