### PR TITLE
Only use ResultsPlotting for plots

### DIFF
--- a/src/Hive.IO/Hive.IO/Plots/DemandMonthlyNormalizedPlot.cs
+++ b/src/Hive.IO/Hive.IO/Plots/DemandMonthlyNormalizedPlot.cs
@@ -14,12 +14,11 @@ namespace Hive.IO.Plots
             var model = new PlotModel { Title = "Energy demand (Normalized Monthly)" };
             var totalFloorArea = results.TotalFloorArea;
 
-            var resultsTotalHeatingMonthly = results.Results.TotalFinalHeatingMonthly ?? new double[months];
             var strokeThickness = 4.0;
 
             var demandHeating = new ColumnSeries
             {
-                ItemsSource = resultsTotalHeatingMonthly.Select(demand => new ColumnItem { Value = demand / totalFloorArea }),
+                ItemsSource = results.TotalHeatingMonthly.Select(demand => new ColumnItem { Value = demand / totalFloorArea }),
                 Title = " Space Heating",
                 FillColor = BackgroundColor,
                 StrokeThickness = strokeThickness,
@@ -27,10 +26,9 @@ namespace Hive.IO.Plots
             };
             model.Series.Add(demandHeating);
 
-            var resultsTotalCoolingMonthly = results.Results.TotalFinalCoolingMonthly ?? new double[months];
             var demandCooling = new ColumnSeries
             {
-                ItemsSource = resultsTotalCoolingMonthly.Select(demand => new ColumnItem { Value = demand / totalFloorArea }),
+                ItemsSource = results.TotalCoolingMonthly.Select(demand => new ColumnItem { Value = demand / totalFloorArea }),
                 Title = " Space Cooling",
                 FillColor = BackgroundColor,
                 StrokeThickness = strokeThickness,
@@ -38,10 +36,9 @@ namespace Hive.IO.Plots
             };
             model.Series.Add(demandCooling);
 
-            var resultsTotalElectricityMonthly = results.Results.TotalFinalElectricityMonthly ?? new double[months];
             var demandElectricity = new ColumnSeries
             {
-                ItemsSource = resultsTotalElectricityMonthly.Select(
+                ItemsSource = results.TotalElectricityMonthly.Select(
                     demand => new ColumnItem { Value = demand / totalFloorArea }),
                 Title = " Electricity",
                 FillColor = BackgroundColor,
@@ -50,10 +47,9 @@ namespace Hive.IO.Plots
             };
             model.Series.Add(demandElectricity);
 
-            var resultsTotalDwhMonthly = results.Results.TotalFinalDomesticHotWaterMonthly ?? new double[months];
             var demandDhw = new ColumnSeries
             {
-                ItemsSource = resultsTotalDwhMonthly.Select(demand => new ColumnItem { Value = demand / totalFloorArea }),
+                ItemsSource = results.TotalDomesticHotWaterMonthly.Select(demand => new ColumnItem { Value = demand / totalFloorArea }),
                 Title = " DWH",
                 FillColor = BackgroundColor,
                 StrokeThickness = strokeThickness,

--- a/src/Hive.IO/Hive.IO/Plots/DemandMonthlyPlot.cs
+++ b/src/Hive.IO/Hive.IO/Plots/DemandMonthlyPlot.cs
@@ -13,37 +13,33 @@ namespace Hive.IO.Plots
             const int months = 12;
             var model = new PlotModel { Title = "Energy demand (Total Monthly)" };
 
-            var resultsTotalHeatingMonthly = results.Results.TotalFinalHeatingMonthly ?? new double[months];
             var demandHeating = new ColumnSeries
             {
-                ItemsSource = resultsTotalHeatingMonthly.Select(demand => new ColumnItem { Value = demand }),
+                ItemsSource = results.TotalHeatingMonthly.Select(demand => new ColumnItem { Value = demand }),
                 Title = " Space Heating",
                 FillColor = SpaceHeatingColor
             };
             model.Series.Add(demandHeating);
 
-            var resultsTotalCoolingMonthly = results.Results.TotalFinalCoolingMonthly ?? new double[months];
             var demandCooling = new ColumnSeries
             {
-                ItemsSource = resultsTotalCoolingMonthly.Select(demand => new ColumnItem { Value = demand }),
+                ItemsSource = results.TotalCoolingMonthly.Select(demand => new ColumnItem { Value = demand }),
                 Title = " Space Cooling",
                 FillColor = SpaceCoolingColor
             };
             model.Series.Add(demandCooling);
 
-            var resultsTotalElectricityMonthly = results.Results.TotalFinalElectricityMonthly ?? new double[months];
             var demandElectricity = new ColumnSeries
             {
-                ItemsSource = resultsTotalElectricityMonthly.Select(demand => new ColumnItem { Value = demand }),
+                ItemsSource = results.TotalElectricityMonthly.Select(demand => new ColumnItem { Value = demand }),
                 Title = " Electricity",
                 FillColor = ElectricityColor
             };
             model.Series.Add(demandElectricity);
 
-            var resultsTotalDwhMonthly = results.Results.TotalFinalDomesticHotWaterMonthly ?? new double[months];
             var demandDhw = new ColumnSeries
             {
-                ItemsSource = resultsTotalDwhMonthly.Select(demand => new ColumnItem { Value = demand }),
+                ItemsSource = results.TotalDomesticHotWaterMonthly.Select(demand => new ColumnItem { Value = demand }),
                 Title = " DWH",
                 FillColor = DhwColor,
             };

--- a/src/Hive.IO/Hive.IO/Results/ResultsPlotting.cs
+++ b/src/Hive.IO/Hive.IO/Results/ResultsPlotting.cs
@@ -18,6 +18,13 @@ namespace Hive.IO.Results
 
         public double TotalFloorArea => Results.TotalFloorArea;
 
+        #region Demand Monthly
+        public double[] TotalHeatingMonthly => Results.TotalFinalHeatingMonthly ?? new double[Misc.MonthsPerYear];
+        public double[] TotalCoolingMonthly => Results.TotalFinalCoolingMonthly ?? new double[Misc.MonthsPerYear];
+        public double[] TotalElectricityMonthly => Results.TotalFinalElectricityMonthly ?? new double[Misc.MonthsPerYear];
+        public double[] TotalDomesticHotWaterMonthly => Results.TotalFinalDomesticHotWaterMonthly ?? new double[Misc.MonthsPerYear];
+        #endregion
+
         #region Emissions
 
         public double[] EmbodiedEmissionsBuildingsMonthly(bool normalized)


### PR DESCRIPTION
This PR addresses #410 - the demand monthly data plots now use `ResultsPlotting` instead of `Hive.Results.Results`.

I did _not_ move the `AmrPlotDataAdaptor` and subclasses to `ResultsPlotting` because... well, because the whole _point_ of the `AmrPlotDataAdaptor` is to "point" the plot to the correct properties in `ResultsPlotting` based on the current KPI.