### PR TITLE
set PV and ST cost and emission parameters to fixed in energy systems form

### DIFF
--- a/src/Hive.IO/Hive.IO/Forms/PhotovoltaicProperties.xaml
+++ b/src/Hive.IO/Hive.IO/Forms/PhotovoltaicProperties.xaml
@@ -51,7 +51,7 @@
             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Efficiency}" IsEnabled="False" />
             <Label Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2">Specific Embodied Emissions</Label>
             <TextBox Grid.Row="3" Grid.Column="0" Text="{Binding SpecificEmbodiedEmissions}"
-                     IsEnabled="{Binding IsEditable}"
+                     IsEnabled="False"
                      Foreground="{Binding SpecificEmbodiedEmissionsBrush}"
                      FontWeight="{Binding SpecificEmbodiedEmissionsFontWeight}" />
             <Label Grid.Row="3" Grid.Column="1">(kgCO₂/m²)</Label>
@@ -76,7 +76,7 @@
             <TextBox Grid.Row="1" Grid.Column="0" Text="{Binding SurfaceTechCapacity, Mode=OneWay, StringFormat=0.00}" IsEnabled="False" />
             <Label Grid.Row="1" Grid.Column="1">(kWp)</Label>
             <Label Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2">Specific Capital Cost</Label>
-            <TextBox Grid.Row="3" Grid.Column="0" Text="{Binding SpecificCapitalCost}" IsEnabled="{Binding IsEditable}"
+            <TextBox Grid.Row="3" Grid.Column="0" Text="{Binding SpecificCapitalCost}" IsEnabled="False"
                      Foreground="{Binding SpecificCapitalCostBrush}"
                      FontWeight="{Binding SpecificCapitalCostFontWeight}" />
             <Label Grid.Row="3" Grid.Column="1">(CHF/m²)</Label>


### PR DESCRIPTION
This PR addresses #473. We took the easy route and just made the fields not editable. The reasoning is that otherwise, we'd need to redo how the `ModuleType` works.