### PR TITLE
fixes #504 (building-component-disappears-when-plugging-in-parametric input)

### DIFF
--- a/src/Hive.IO/Hive.IO/GhInputOutput/GhBuilding.cs
+++ b/src/Hive.IO/Hive.IO/GhInputOutput/GhBuilding.cs
@@ -45,13 +45,13 @@ namespace Hive.IO.GhInputOutput
         {
             if (_buildingInputState == null)
             {
-                return false;
+                return base.Write(writer);
             }
 
             if (!_buildingInputState.IsEditable)
             {
                 // don't bother writing down parametric input
-                return false;
+                return base.Write(writer);
             }
 
             try
@@ -63,7 +63,7 @@ namespace Hive.IO.GhInputOutput
             {
                 RhinoApp.WriteLine($"GhBuilding.Write() failed!! {ex}");
                 Message = "Failed to write state to Document";
-                return false;
+                return base.Write(writer);
             }
         }
 


### PR DESCRIPTION
This one nearly drove me nuts. It turns out, you _need_ to call the base `Write` in every case. I works now. See #504 for a description of the steps to reproduce the error.