### PR TITLE
725 Normalized axis limit input

### DIFF
--- a/src/Hive.IO/Hive.IO/Forms/VisualizerPlotProperties.cs
+++ b/src/Hive.IO/Hive.IO/Forms/VisualizerPlotProperties.cs
@@ -16,10 +16,16 @@ namespace Hive.IO.Forms
 
         private int locationX;
         private int locationY;
-        public VisualizerPlotProperties()
+        private bool IsNormalizedAxis = false;
+        private bool IsSolarGainsPlot = false;
+        public VisualizerPlotProperties(string currentPlot)
         {
             this.locationX = Cursor.Position.X;
             this.locationY = Cursor.Position.Y;
+
+            IsNormalizedAxis = currentPlot.Contains("Normalized") ? true : false;
+            IsSolarGainsPlot = currentPlot.Contains("SolarGains") ? true : false;
+
             Load += new EventHandler(VisualizerPlotProperties_Load);
             InitializeComponent();
         }
@@ -27,6 +33,11 @@ namespace Hive.IO.Forms
         private void VisualizerPlotProperties_Load(object sender, System.EventArgs e)
         {
             this.SetDesktopLocation(locationX, locationY);
+
+            if (IsSolarGainsPlot)
+            {
+                this.tabControl1.SelectedTab = this.tabPage2;
+            }
         }
 
         /// <summary>

--- a/src/Hive.IO/Hive.IO/Forms/VisualizerPlotProperties.cs
+++ b/src/Hive.IO/Hive.IO/Forms/VisualizerPlotProperties.cs
@@ -49,10 +49,21 @@ namespace Hive.IO.Forms
                 _plotParameters = value;
 
                 // add the data to the controls
-                txtEnergyDemandMinimum.Text = ReadParameter("EnergyDemandMonthly-Axis-Minimum");
-                txtEnergyDemandMaximum.Text = ReadParameter("EnergyDemandMonthly-Axis-Maximum");
-                txtSolarGainsMinimum.Text = ReadParameter("SolarGains-Axis-Minimum");
-                txtSolarGainsMaximum.Text = ReadParameter("SolarGains-Axis-Maximum");
+                if (!IsNormalizedAxis)
+                {
+                    txtEnergyDemandMinimum.Text = ReadParameter("EnergyDemandMonthly-Axis-Minimum");
+                    txtEnergyDemandMaximum.Text = ReadParameter("EnergyDemandMonthly-Axis-Maximum");
+                    txtSolarGainsMinimum.Text = ReadParameter("SolarGains-Axis-Minimum");
+                    txtSolarGainsMaximum.Text = ReadParameter("SolarGains-Axis-Maximum");
+                } else
+                {
+                    txtEnergyDemandMinimum.Text = ReadParameter("EnergyDemandNormalized-Axis-Minimum");
+                    txtEnergyDemandMaximum.Text = ReadParameter("EnergyDemandNormalized-Axis-Maximum");
+                    txtSolarGainsMinimum.Text = ReadParameter("SolarGainsNormalized-Axis-Minimum");
+                    txtSolarGainsMaximum.Text = ReadParameter("SolarGainsNormalized-Axis-Maximum");
+                }
+                
+                
             }
         }
 
@@ -78,10 +89,20 @@ namespace Hive.IO.Forms
         /// <param name="e"></param>
         private void btnSave_Click(object sender, EventArgs e)
         {
-            WriteDoubleParameter("EnergyDemandMonthly-Axis-Minimum", txtEnergyDemandMinimum.Text);
-            WriteDoubleParameter("EnergyDemandMonthly-Axis-Maximum", txtEnergyDemandMaximum.Text);
-            WriteDoubleParameter("SolarGains-Axis-Minimum", txtSolarGainsMinimum.Text);
-            WriteDoubleParameter("SolarGains-Axis-Maximum", txtSolarGainsMaximum.Text);
+            if (!IsNormalizedAxis)
+            {
+                WriteDoubleParameter("EnergyDemandMonthly-Axis-Minimum", txtEnergyDemandMinimum.Text);
+                WriteDoubleParameter("EnergyDemandMonthly-Axis-Maximum", txtEnergyDemandMaximum.Text);
+                WriteDoubleParameter("SolarGains-Axis-Minimum", txtSolarGainsMinimum.Text);
+                WriteDoubleParameter("SolarGains-Axis-Maximum", txtSolarGainsMaximum.Text);
+            } else
+            {
+                WriteDoubleParameter("EnergyDemandNormalized-Axis-Minimum", txtEnergyDemandMinimum.Text);
+                WriteDoubleParameter("EnergyDemandNormalized-Axis-Maximum", txtEnergyDemandMaximum.Text);
+                WriteDoubleParameter("SolarGainsNormalized-Axis-Minimum", txtSolarGainsMinimum.Text);
+                WriteDoubleParameter("SolarGainsNormalized-Axis-Maximum", txtSolarGainsMaximum.Text);
+            }
+            
         }
 
         private void btnResetDemandAxis_Click(object sender, EventArgs e)

--- a/src/Hive.IO/Hive.IO/Forms/VisualizerPlotProperties.cs
+++ b/src/Hive.IO/Hive.IO/Forms/VisualizerPlotProperties.cs
@@ -33,11 +33,8 @@ namespace Hive.IO.Forms
         private void VisualizerPlotProperties_Load(object sender, System.EventArgs e)
         {
             this.SetDesktopLocation(locationX, locationY);
+            this.tabControl1.SelectedTab = IsSolarGainsPlot ? this.tabPage2 : this.tabPage1;
 
-            if (IsSolarGainsPlot)
-            {
-                this.tabControl1.SelectedTab = this.tabPage2;
-            }
         }
 
         /// <summary>

--- a/src/Hive.IO/Hive.IO/GhInputOutput/GhVisualizerAttributes.cs
+++ b/src/Hive.IO/Hive.IO/GhInputOutput/GhVisualizerAttributes.cs
@@ -155,10 +155,11 @@ namespace Hive.IO.GhInputOutput
 
         public override GH_ObjectResponse RespondToMouseDoubleClick(GH_Canvas sender, GH_CanvasMouseEvent e)
         {
+            var currentPlot = _plotSelector._currentPlot.ToString();
             // show properties dialog if mouse is in Y axis box
-            if (YAxisBounds.Contains(e.CanvasLocation) && AxisLimitPlots.Contains(_plotSelector._currentPlot.ToString()))
+            if (YAxisBounds.Contains(e.CanvasLocation) && AxisLimitPlots.Contains(currentPlot))
             {
-                var propertiesDialog = new VisualizerPlotProperties();
+                var propertiesDialog = new VisualizerPlotProperties(currentPlot);
                 propertiesDialog.PlotParameters = Owner.PlotProperties;
                 propertiesDialog.ShowDialog();
 
@@ -172,7 +173,8 @@ namespace Hive.IO.GhInputOutput
         //this might be a really bad idea performance-wise?
         public override GH_ObjectResponse RespondToMouseMove(GH_Canvas sender, GH_CanvasMouseEvent e)
         {
-            if (YAxisBounds.Contains(e.CanvasLocation) && AxisLimitPlots.Contains(_plotSelector._currentPlot.ToString()))
+            var currentPlot = _plotSelector._currentPlot.ToString();            
+            if (YAxisBounds.Contains(e.CanvasLocation) && AxisLimitPlots.Contains(currentPlot))
             {
                 InYAXisBounds = true;
                 sender.Invalidate();

--- a/src/Hive.IO/Hive.IO/Plots/DemandMonthlyNormalizedPlot.cs
+++ b/src/Hive.IO/Hive.IO/Plots/DemandMonthlyNormalizedPlot.cs
@@ -56,12 +56,24 @@ namespace Hive.IO.Plots
             };
             model.Series.Add(demandDhw);
 
-            model.Axes.Add(new LinearAxis
+            var axis = new LinearAxis
             {
                 Position = AxisPosition.Left,
                 Key = "Demand",
-                Title = "kWh/m²"
-            });
+                Title = "kWh/m²",
+            };
+            var axisMinimum = plotParameters.ReadDouble("EnergyDemandNormalized-Axis-Minimum");
+            if (axisMinimum.HasValue)
+            {
+                axis.Minimum = axisMinimum.Value;
+            }
+
+            var axisMaximum = plotParameters.ReadDouble("EnergyDemandNormalized-Axis-Maximum");
+            if (axisMaximum.HasValue)
+            {
+                axis.Maximum = axisMaximum.Value;
+            }
+            model.Axes.Add(axis);
 
             model.Axes.Add(new CategoryAxis
             {

--- a/src/Hive.IO/Hive.IO/Plots/SolarGainsPerWindowPlot.cs
+++ b/src/Hive.IO/Hive.IO/Plots/SolarGainsPerWindowPlot.cs
@@ -40,6 +40,19 @@ namespace Hive.IO.Plots
                 });
             }
 
+            double? axisMinimum = new double();
+            double? axisMaximum = new double();
+            if (Normalize)
+            {
+                axisMinimum = plotParameters.ReadDouble("SolarGainsNormalized-Axis-Minimum");
+                axisMaximum = plotParameters.ReadDouble("SolarGainsNormalized-Axis-Maximum");
+            } else
+            {
+                axisMinimum = plotParameters.ReadDouble("SolarGains-Axis-Minimum");
+                axisMaximum = plotParameters.ReadDouble("SolarGains-Axis-Maximum");
+            }
+            
+            
             // add the axes
             var axis = new LinearAxis
             {
@@ -47,13 +60,12 @@ namespace Hive.IO.Plots
                 Key = "Irradiation",
                 Title = Units
             };
-            var axisMinimum = plotParameters.ReadDouble("SolarGains-Axis-Minimum");
+            
             if (axisMinimum.HasValue)
             {
                 axis.Minimum = axisMinimum.Value;
             }
-
-            var axisMaximum = plotParameters.ReadDouble("SolarGains-Axis-Maximum");
+            
             if (axisMaximum.HasValue)
             {
                 axis.Maximum = axisMaximum.Value;


### PR DESCRIPTION
## Issues

Closes #725

## Description

- @christophwaibel Not sure if this is the intended behaviour. Axis limit values are seperate for regular and normalized plots and are loaded and displayed depending on the version (regular/normalized) of the plot that is currently selected. Let me know what you think!

## Checklist

- [x] Remove debugging artifacts (if needed)
- [x] Rebuild the Setup_Hive.exe
- [ ] Update Hive Wiki (if needed)
- [ ] Update InformationalVersion attribute in Hive.IO/Properties/AssemblyInfo.cs (if it's a new release) 
- [ ] Update most important Grasshopper template(s); as of now [/GrasshopperExamples/LectureExercises/EaCS3_E04_Hive_Template.gh](https://github.com/architecture-building-systems/hive/blob/master/GrasshopperExamples/LectureExercises/EaCS3_E04_Hive_Template.gh)
