### PR TITLE
749 conduit license

### DIFF
--- a/setup/hive.nsi
+++ b/setup/hive.nsi
@@ -52,7 +52,7 @@ RequestExecutionLevel user
 ;--------------------------------
 ;Installer Sections
 
-Section "Hive Installation" Base_Installation_Section
+Section "Hive" Base_Installation_Section
     SectionIn RO  # this section is required
     SetOutPath "$INSTDIR"
 
@@ -126,7 +126,7 @@ Section "Hive Installation" Base_Installation_Section
 
 SectionEnd
 
-Section "Conduit Installation" Conduit_Installation_Section
+Section "Conduit" Conduit_Installation_Section
 
 IfFileExists "$INSTDIR\..\ProvingGround.Conduit.gha" 0 file_not_found
     goto end_of_block
@@ -136,7 +136,7 @@ IfFileExists "$INSTDIR\..\ProvingGround.Conduit.gha" 0 file_not_found
 
 SectionEnd
 
-LangString DESC_Section1 ${LANG_ENGLISH} "This is Hive."
+LangString DESC_Section1 ${LANG_ENGLISH} "Base Hive installation."
 LangString DESC_Section2 ${LANG_ENGLISH} "This is a test description. Installs the Conduit plugin by Proving Ground Apps."
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN

--- a/setup/hive.nsi
+++ b/setup/hive.nsi
@@ -52,7 +52,7 @@ RequestExecutionLevel user
 ;--------------------------------
 ;Installer Sections
 
-Section "Base Installation" Base_Installation_Section
+Section "Hive Installation" Base_Installation_Section
     SectionIn RO  # this section is required
     SetOutPath "$INSTDIR"
 
@@ -125,3 +125,21 @@ Section "Base Installation" Base_Installation_Section
     # File "honey-badger-runtime.dll"        
 
 SectionEnd
+
+Section "Conduit Installation" Conduit_Installation_Section
+
+IfFileExists "$INSTDIR\..\ProvingGround.Conduit.gha" 0 file_not_found
+    goto end_of_block
+    file_not_found:
+    File "ProvingGround.Conduit.gha"
+    end_of_block:
+
+SectionEnd
+
+LangString DESC_Section1 ${LANG_ENGLISH} "This is Hive."
+LangString DESC_Section2 ${LANG_ENGLISH} "This is a test description. Installs the Conduit plugin by Proving Ground Apps."
+
+!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
+  !insertmacro MUI_DESCRIPTION_TEXT ${Base_Installation_Section} $(DESC_Section1)
+  !insertmacro MUI_DESCRIPTION_TEXT ${Conduit_Installation_Section} $(DESC_Section2)
+!insertmacro MUI_FUNCTION_DESCRIPTION_END

--- a/setup/hive.nsi
+++ b/setup/hive.nsi
@@ -136,8 +136,8 @@ IfFileExists "$INSTDIR\..\ProvingGround.Conduit.gha" 0 file_not_found
 
 SectionEnd
 
-LangString DESC_Section1 ${LANG_ENGLISH} "Base Hive installation."
-LangString DESC_Section2 ${LANG_ENGLISH} "This is a test description. Installs the Conduit plugin by Proving Ground Apps."
+LangString DESC_Section1 ${LANG_ENGLISH} "Installs the Hive plugin for Grasshopper."
+LangString DESC_Section2 ${LANG_ENGLISH} "Installs the Conduit plugin by Proving Ground Apps. Conduit is used within Hive for certain chart visualizations. Visit https://apps.proving$\nground.io/conduit/ for more information."
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
   !insertmacro MUI_DESCRIPTION_TEXT ${Base_Installation_Section} $(DESC_Section1)


### PR DESCRIPTION
## Issues

Closes #749

## Description

- Added the MIT licence notive for concuit
- Seperated Hive and Conduit installation in the setup file
- Added a description for Hive and for Conduit in the installation wizard

## Checklist

- [ ] Remove debugging artifacts (if needed)
- [ ] Rebuild the Setup_Hive.exe
- [ ] Update Hive Wiki (if needed)
- [ ] Update InformationalVersion attribute in Hive.IO/Properties/AssemblyInfo.cs (if it's a new release) 
- [ ] Update most important Grasshopper template(s); as of now [/GrasshopperExamples/LectureExercises/EaCS3_E04_Hive_Template.gh](https://github.com/architecture-building-systems/hive/blob/master/GrasshopperExamples/LectureExercises/EaCS3_E04_Hive_Template.gh)
