### PR TITLE
617 heating demand bestand

### DIFF
--- a/src/Hive.IO/Hive.IO/Properties/AssemblyInfo.cs
+++ b/src/Hive.IO/Hive.IO/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.17")]
+[assembly: AssemblyInformationalVersion("1.17.1")]

--- a/src/Hive.IO/Hive.IO/Results/Results.cs
+++ b/src/Hive.IO/Hive.IO/Results/Results.cs
@@ -847,7 +847,7 @@ namespace Hive.IO.Results
                 }
             }
 
-            return Misc.ComputeLevelisedValues(costsYearly, interestRate, buildingLifetime);
+            return Misc.ComputeAnnualizedValues(costsYearly, interestRate, buildingLifetime);
         }
 
         public static double GetTotalCostOperationalConstructionYearlyLevelized(Building.Building building, double interestRate, double buildingLifetime)
@@ -868,7 +868,7 @@ namespace Hive.IO.Results
                 }
             }
 
-            return Misc.ComputeLevelisedValues(costsYearly, interestRate, buildingLifetime);
+            return Misc.ComputeAnnualizedValues(costsYearly, interestRate, buildingLifetime);
         }
 
         // FIX ME energy costs?
@@ -907,7 +907,7 @@ namespace Hive.IO.Results
                 }
             }
 
-            return Misc.ComputeLevelisedValues(emissionsYearly, 0.0, buildingLifetime);
+            return Misc.ComputeAnnualizedValues(emissionsYearly, 0.0, buildingLifetime);
         }
 
         public static double GetTotalEmissionsOperationalConstructionYearlyLevelized(Building.Building building, double buildingLifetime)
@@ -937,7 +937,7 @@ namespace Hive.IO.Results
                 }
             }
 
-            return Misc.ComputeLevelisedValues(emissionsYearly, 0.0, buildingLifetime);
+            return Misc.ComputeAnnualizedValues(emissionsYearly, 0.0, buildingLifetime);
         }
 
         public static double[] GetTotalEmissionsOperationalSystemsMonthly(List<ConversionTech> conversionTech)

--- a/src/Hive.IO/Hive.IO/Util/Misc.cs
+++ b/src/Hive.IO/Hive.IO/Util/Misc.cs
@@ -256,7 +256,7 @@ namespace Hive.IO
         /// <param name="interestRate">The real discount rate (includes inflation)</param>
         /// <param name="projectLifetime">The duration of the entire projects lifetime</param>
         /// <returns>Levelised values in units provided for duration of projectLifetime.</returns>
-        public static double ComputeLevelisedValues(double[] valuesNonLevelised, double interestRate, double projectLifetime)
+        public static double ComputeAnnualizedValues(double[] valuesNonLevelised, double interestRate, double projectLifetime)
         {
             // From (with real discount rate) https://www.homerenergy.com/products/pro/docs/latest/capital_recovery_factor.html
             double CapitalRecoveryFactor(double i, double N) => i != 0 ? i * Math.Pow(1 + i, N) / (Math.Pow(1 + i, N) - 1) : 1;


### PR DESCRIPTION
# Fixed Bug for casting "NaN" in "Bestand" parameters

## Issues
Closes #617 

## Description
In the building input form, when selecting "Wohnen" and "Bestand", it had "NaN" as parameter in heat recovery. That didn't work for the `GhSIA2024RoomReader.cs`. 

## Checklist

- [x] Remove debugging artifacts (if needed)
- [x] Rebuild the Setup_Hive.exe
- [ ] Update Hive Wiki (if needed)
- [x] Update InformationalVersion attribute in Hive.IO/Properties/AssemblyInfo.cs (if it's a new release) 
- [ ] Update most important Grasshopper template(s); as of now [/GrasshopperExamples/LectureExercises/EaCS3_E04_Hive_Template.gh](https://github.com/architecture-building-systems/hive/blob/master/GrasshopperExamples/LectureExercises/EaCS3_E04_Hive_Template.gh)
