### PR TITLE
modified KPI color & transparency

### DIFF
--- a/src/Hive.IO/Hive.IO/GhInputOutput/GhVisualizerAttributes.cs
+++ b/src/Hive.IO/Hive.IO/GhInputOutput/GhVisualizerAttributes.cs
@@ -89,16 +89,16 @@ namespace Hive.IO.GhInputOutput
             var energyKpiToolTip = new VisualizerToolTip(
                 "Energy KPI",
                 "Annual operational final energy consumption for heating, cooling, electricity and domestic hot water.", 
-                _kpiPlots[2], new SolidBrush(Color.LightBlue), 70);
+                _kpiPlots[2], new SolidBrush(Color.FromArgb(180, 225, 242, 31)), 70);
 
             var emissionKpiToolTip = new VisualizerToolTip("Emissions KPI",
                 "Annual operational carbon emissions for heating, cooling, electricity and domestic hot water, and annualized embodied carbon emissions of the building construction considering the expected building lifetime.", 
-                _kpiPlots[1], new SolidBrush(Color.LightBlue), 70);
+                _kpiPlots[1], new SolidBrush(Color.FromArgb(180, 136, 219, 68)), 70);
 
             var costKpiToolTip = new VisualizerToolTip(
                 "Cost KPI",
                 "Annual operational cost for heating, cooling, electricity and domestic hot water, and annualized construction cost considering the expected building lifetime.", 
-                _kpiPlots[0], new SolidBrush(Color.LightBlue), 70);
+                _kpiPlots[0], new SolidBrush(Color.FromArgb(180, 222, 180, 109)), 70);
 
             _toolTips = new VisualizerToolTip[]
             {


### PR DESCRIPTION
# [Title]

## Issues

Closes #772 

## Description

- KPI Tooltips now have matching, transparent background colors

## Checklist

- [ ] Remove debugging artifacts (if needed)
- [x] Rebuild the Setup_Hive.exe
- [ ] Update Hive Wiki (if needed)
- [ ] Update InformationalVersion attribute in Hive.IO/Properties/AssemblyInfo.cs (if it's a new release) 
- [ ] Update most important Grasshopper template(s); as of now [/GrasshopperExamples/LectureExercises/EaCS3_E04_Hive_Template.gh](https://github.com/architecture-building-systems/hive/blob/master/GrasshopperExamples/LectureExercises/EaCS3_E04_Hive_Template.gh)
