### PR TITLE
renamed label in amr plot because slightly misleading

### DIFF
--- a/src/Hive.IO/Hive.IO/Hive.IO.csproj
+++ b/src/Hive.IO/Hive.IO/Hive.IO.csproj
@@ -71,9 +71,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
-    </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />

--- a/src/Hive.IO/Hive.IO/Plots/AmrPlotBase.cs
+++ b/src/Hive.IO/Hive.IO/Plots/AmrPlotBase.cs
@@ -215,8 +215,8 @@ namespace Hive.IO.Plots
 
         private void RenderLeftAxis(Graphics graphics)
         {
-            graphics.DrawStringVertical("Buildings", BoldFont, TextBrush, BuildingsLeftAxisBounds);
-            graphics.DrawStringVertical("Systems", BoldFont, TextBrush, SystemsLeftAxisBounds);
+            graphics.DrawStringVertical("Building / Construction", BoldFont, TextBrush, BuildingsLeftAxisBounds);
+            graphics.DrawStringVertical("Energy System", BoldFont, TextBrush, SystemsLeftAxisBounds);
         }
 
         private void RenderRightAxis(Graphics graphics)

--- a/src/Hive.IO/Hive.IO/packages.config
+++ b/src/Hive.IO/Hive.IO/packages.config
@@ -2,9 +2,8 @@
 <packages>
   <package id="Grasshopper" version="7.28.23058.3001" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
-  <package id="OxyPlot.Core" version="2.0.0" targetFramework="net45" />
-  <package id="OxyPlot.WindowsForms" version="2.0.0" targetFramework="net45" />
+  <package id="OxyPlot.Core" version="2.0.0" targetFramework="net48" />
+  <package id="OxyPlot.WindowsForms" version="2.0.0" targetFramework="net48" />
   <package id="RhinoCommon" version="7.28.23058.3001" targetFramework="net48" />
   <package id="System.Collections.Specialized" version="4.3.0" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" requireReinstallation="true" />
 </packages>

--- a/src/Hive.IO/TestVisualizer/packages.config
+++ b/src/Hive.IO/TestVisualizer/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Grasshopper" version="7.29.23107.3001" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
-  <package id="OxyPlot.Core" version="2.0.0" targetFramework="net472" />
-  <package id="OxyPlot.WindowsForms" version="2.0.0" targetFramework="net472" />
+  <package id="OxyPlot.Core" version="2.0.0" targetFramework="net48" />
+  <package id="OxyPlot.WindowsForms" version="2.0.0" targetFramework="net48" />
   <package id="RhinoCommon" version="7.29.23107.3001" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
closes #822 

![image](https://github.com/architecture-building-systems/hive/assets/21927657/66191362-ffaa-40fa-aacd-0d4659f77025)

## Checklist

- [ ] Remove debugging artifacts (if needed)
- [x] Rebuild the Setup_Hive.exe
- [ ] Update Hive Wiki (if needed)
- [ ] Update InformationalVersion attribute in Hive.IO/Properties/AssemblyInfo.cs (if it's a new release) 
- [ ] Update most important Grasshopper template(s); as of now [/GrasshopperExamples/LectureExercises/EaCS3_E04_Hive_Template.gh](https://github.com/architecture-building-systems/hive/blob/master/GrasshopperExamples/LectureExercises/EaCS3_E04_Hive_Template.gh)
